### PR TITLE
Change PPA name

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ layout: base
         <li class="p-inline-list__item"><a href="/docs" class="p-button--positive u-no-margin--bottom-small">Docs</a></li>
         <li class="p-inline-list__item"><a href="https://github.com/canonical/dqlite/releases" class="p-button--neutral u-no-margin--bottom-small">Download</a></li>
       </ul>
-      <p>or on Ubuntu: <pre class="p-code-numbered"><code><span class="p-code-numbered__line">sudo add-apt-repository -y ppa:dqlite/v1 && sudo apt install dqlite</span></code></pre></p>
+      <p>or on Ubuntu: <pre class="p-code-numbered"><code><span class="p-code-numbered__line">sudo add-apt-repository -y ppa:dqlite/stable && sudo apt install dqlite</span></code></pre></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Change PPA name from dqlite/v1 to dqlite/stable, as suggested by Mark. The change is already effective in Launchpad, the old PPA will be kept around for a while for people pointing to it.