### PR TITLE
Change reference to OS X to macOS

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,7 +7,7 @@ layout: docs
 
 1. [What are the use cases?](#what-are-the-use-cases)
 2. [Who's using dqlite?](#whos-using-dqlite)
-3. [Are Windows and OSX supported?](#are-windows-and-osx-supported)
+3. [Are Windows and macOS supported?](#are-windows-and-macos-supported)
 4. [Is there 24/7 support available?](#is-there-247-support-available)
 5. [Is there a commitment to long term releases?](#is-there-a-commitment-to-long-term-releases)
 6. [How does dqlite behave during conflict situations?](#how-does-dqlite-behave-during-conflict-situations)
@@ -34,7 +34,7 @@ which uses dqlite to implement high-availability when run in cluster mode. See
 the relevant
 [documentation](https://github.com/lxc/lxd/blob/master/doc/clustering).
 
-## Are Windows and OSX supported?
+## Are Windows and macOS supported?
 
 Not at the moment, because under the hood dqlite uses the Linux-specific
 `io_submit` asynchronous file system write API. That code leaves behind an


### PR DESCRIPTION
## Done
Replace OSX with macOS in the FAQ docs. Keeping in line with upstream: https://github.com/canonical/dqlite/commit/5490b4028b3217391a49a73ee37d46b750eb1e3b
