### PR TITLE
Sync docs with dqlite GH repo

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,7 +33,7 @@ At the moment the biggest user of dqlite is the
 [LXD](https://linuxcontainers.org/lxd/introduction/) system containers manager,
 which uses dqlite to implement high-availability when run in cluster mode. See
 the relevant
-[documentation](https://github.com/lxc/lxd/blob/master/doc/clustering).
+[documentation](https://github.com/lxc/lxd/blob/master/doc/clustering.md).
 
 ## Are Windows and macOS supported?
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -166,26 +166,6 @@ associated schemas:
 | uint64 | Currently unused         |
 | text   | Currently unused         |
 
-### **0** - Get current leader
-
-| Type   | Value        |
-| ------ | ------------ |
-| uint64 | Unused field |
-
-### **1** - Client registration
-
-| Type   | Value            |
-| ------ | ---------------- |
-| uint64 | ID of the client |
-
-### **3** - Open a database
-
-| Type   | Value                    |
-| ------ | ------------------------ |
-| text   | The name of the database |
-| uint64 | Currently unused         |
-| text   | Currently unused         |
-
 ### **4** - Prepare a statement
 
 | Type   | Value                          |


### PR DESCRIPTION
These docs have now been deleted from the github.com/canonical/raft repository,
so the dqlite.io one is now the source of truth.