### PR TITLE
Add discourse navigation item

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -78,6 +78,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <li class="p-navigation__link" role="menuitem">
             <a href="/docs">Docs</a>
           </li>
+	  <li class="p-navigation__link" role="menuitem">
+	    <a href="https://discourse.dqlite.io">Discourse</a>
+	  </li>
           <li class="p-navigation__link" role="menuitem">
             <a class="p-link--external" href="https://github.com/canonical/dqlite">Code</a>
           </li>


### PR DESCRIPTION
## Done
Add discourse navigation item

## QA
- Load the demo
- Click the discourse navigation item
- Check it loads the discourse
- Click the dqlite logo on discourse and check it jumps back to the site