### PR TITLE
Fix Python dependencies issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # Install python and import python dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-lib2to3 python3-pkg-resources
+RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-setuptools python3-lib2to3 python3-pkg-resources
 ENV PATH="/root/.local/bin:${PATH}"
 
 # Copy python dependencies


### PR DESCRIPTION
## Done

Fix Python dependencies issue

## QA

- Pull the branch
- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag test .`
- `docker run -ti -p "8037:80" --env SECRET_KEY=secret_key test`
