### PR TITLE
Add codecov badge to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # dqlite.io
+
+[![Code coverage](https://codecov.io/gh/canonical-web-and-design/dqlite.io/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/dqlite.io)
+
 This is the repo for the [dqlite.io website](https://dqlite.io).
 
 ## Usage


### PR DESCRIPTION
## Done

Added a codecov badge to the README which should display at the bottom of the main page of the repo.

## QA

- Check out this feature branch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the badge appears correctly.


## Issue / Card

Fixes web-squad#2986