### PR TITLE
Add a link to adjust tracking management to the footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.3",
-    "@canonical/cookie-policy": "3.0.1",
+    "@canonical/cookie-policy": "3.0.2",
     "autoprefixer": "9.8.6",
     "babel-eslint": "10.1.0",
     "eslint": "7.8.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-canonicalwebteam.flask-base==0.6.3
+canonicalwebteam.flask-base==0.6.4
 canonicalwebteam.discourse-docs==1.0.1

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -14,6 +14,9 @@
               Report a bug on this site
             </a>
           </li>
+          <li class="p-inline-list__item">
+            <a href="" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+          </li>
         </ul>
         <span class="u-off-screen">
           <a href="#">Go to the top of the page</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,10 +1400,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.1.tgz#88accc1184c2ff954938e0bade52d90ee372c6ba"
-  integrity sha512-b6xb0xIreWVQifMsYi0ji9pGpeNj0SEcKhCt/H6a5DP0mqfrzsHxLLev7B4EbTss3oN4L6YgreBOm3oijE1oKQ==
+"@canonical/cookie-policy@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.2.tgz#5a6a3d5f02c2fc139e38749e25e14254d4b3cdd8"
+  integrity sha512-xe25hHA9jrfgWTs+pVjO4UL/INnM1Pp0ukYgolMYTc+kwSguAmnXXDN3vhoSOToS6DPU5E6yh7U/wQqXVqos7g==
 
 "@canonical/global-nav@2.4.3":
   version "2.4.3"


### PR DESCRIPTION
## Done
Bump cookie-policy to 3.0.2
Add a link to adjust tracking management to the footer

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8037
- Check you see the cookie notification with manager
- Make a choice
- Go to the footer and click the "Manage your tracker settings" link in the footer and see it brings the notification back up