### PR TITLE
Add were hiring to the site

### DIFF
--- a/static/js/global-nav.js
+++ b/static/js/global-nav.js
@@ -1,3 +1,6 @@
 import { createNav } from "@canonical/global-nav";
 
-createNav({ maxWidth: "72rem" });
+createNav({ 
+  maxWidth: "72rem", 
+  hiring: "https://canonical.com/careers/2413536"
+});


### PR DESCRIPTION
## Done
Added were hiring option to the global nav.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8037
- Check the global nav as a link in the global nav to the careers page.
