### PR TITLE
Remove we're hiring from the site

### DIFF
--- a/static/js/global-nav.js
+++ b/static/js/global-nav.js
@@ -1,6 +1,3 @@
 import { createNav } from "@canonical/global-nav";
 
-createNav({ 
-  maxWidth: "72rem", 
-  hiring: "https://canonical.com/careers/2413536"
-});
+createNav({ maxWidth: "72rem" });


### PR DESCRIPTION
## Done

Remove the hiring option from the global nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8037
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that hiring is not mentioned in the global nav


## Issue / Card

Fixes #86
