### PR TITLE
Move from node:12-slim to node:12 and fix staging/prod builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:12-slim AS yarn-dependencies
+FROM node:12 AS yarn-dependencies
 WORKDIR /srv
 COPY . .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install


### PR DESCRIPTION
Update docker to node:12 and fix staging/prod builds

## Done

Update node:12

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- See that the demo runs