### PR TITLE
Replace home-grown, deprecated use of code-numbered with code-snippet

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -48,15 +48,6 @@
   }
 }
 
-.p-code-numbered__line {
-  padding: 0.5rem 1rem 0 4rem;
-
-  &::before {
-    content: "$";
-    width: 3rem;
-  }
-}
-
 // XXX Remove the top border on a Matrix on small screesn
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2517
 .p-matrix {

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
         <li class="p-inline-list__item"><a href="/docs" class="p-button--positive u-no-margin--bottom-small">Docs</a></li>
         <li class="p-inline-list__item"><a href="https://github.com/canonical/dqlite/releases" class="p-button--neutral u-no-margin--bottom-small">Download</a></li>
       </ul>
-      <p>or on Ubuntu: <pre class="p-code-numbered"><code><span class="p-code-numbered__line">sudo add-apt-repository -y ppa:dqlite/stable && sudo apt install dqlite</span></code></pre></p>
+      <p>or on Ubuntu: <div class="p-code-snippet"><pre class="p-code-snippet__block--icon"><code>sudo add-apt-repository -y ppa:dqlite/stable && sudo apt install dqlite</code></pre></div></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Replaced the old code-numbered pattern, with its custom rule to override the number with a prompt symbol,  with a code-snippet pattern from newer Vanilla, which already includes the prompt symbol.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8037
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #116

## Screenshots

![Captura de pantalla de 2021-06-17 15-22-56](https://user-images.githubusercontent.com/554953/122467282-f4cffe00-cf7f-11eb-8fc0-66bb0a36a39b.png)
