### PR TITLE
A11y pass over

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -14,6 +14,10 @@
   padding-right: 33px !important;
 }
 
+.skip-content {
+  background-color: $color-x-light;
+}
+
 .p-navigation {
   .p-navigation__row {
     padding: 0;
@@ -22,7 +26,8 @@
       padding: 0 $sph-inner--large;
 
       .p-navigation__logo {
-        font-weight: 400;
+        font-size: 19px;
+        font-weight: 700;
         margin-right: 0;
       }
 
@@ -45,13 +50,5 @@
 .u-no-margin--bottom-small {
   @media only screen and (min-width: $breakpoint-medium) {
     margin-bottom: 0 !important;
-  }
-}
-
-// XXX Remove the top border on a Matrix on small screesn
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/2517
-.p-matrix {
-  &__item:first-of-type {
-    border-top: 0;
   }
 }

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -67,7 +67,7 @@
 
   {% include "partial/_navigation.html" %}
 
-  <div id="main">
+  <div id="main-content">
     {% block content %}{% endblock content %}
   </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'base_layout.html' %}
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/8bc629a7-microk8s-suru-background.svg'); background-size: cover;">
+<section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/8bc629a7-microk8s-suru-background.svg'); background-color: #000000; background-size: cover;">
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>High-availability SQLite</h1>
@@ -18,17 +18,27 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      <p>Dqlite (“distributed SQLite”) extends SQLite across a cluster of machines, with automatic failover and high-availability to keep your application running. It uses <a href="https://github.com/canonical/raft">C-Raft</a>, an optimised Raft implementation in C, to gain high-performance transactional consensus and fault tolerance while preserving SQlite’s  outstanding efficiency and tiny footprint.</p>
+      <h2>Getting started</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p>Dqlite (distributed SQLite) extends SQLite across a cluster of machines, with automatic failover and high-availability to keep your application running. It uses <a href="https://github.com/canonical/raft" class="p-link--external" aria-label="External link to the C-Raft Github project page">C-Raft</a>, an optimised Raft implementation in C, to gain high-performance transactional consensus and fault tolerance while preserving SQlite’s  outstanding efficiency and tiny footprint.</p>
       <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="/docs" class="p-button--positive u-no-margin--bottom-small">Docs</a></li>
-        <li class="p-inline-list__item"><a href="https://github.com/canonical/dqlite/releases" class="p-button--neutral u-no-margin--bottom-small">Download</a></li>
+        <li class="p-inline-list__item"><a href="/docs" class="p-button--positive u-no-margin--bottom-small">Read the Dqlite docs</a></li>
+        <li class="p-inline-list__item"><a href="https://github.com/canonical/dqlite/releases" class="p-button--neutral u-no-margin--bottom-small p-link--external" aria-label="External link to the Dqlite releases page on Github">Download Dqlite</a></li>
       </ul>
-      <p>or on Ubuntu: <div class="p-code-snippet"><pre class="p-code-snippet__block--icon"><code>sudo add-apt-repository -y ppa:dqlite/stable && sudo apt install dqlite</code></pre></div></p>
+      <p>install on Ubuntu: <div class="p-code-snippet"><pre class="p-code-snippet__block--icon"><code>sudo add-apt-repository -y ppa:dqlite/stable && sudo apt install dqlite</code></pre></div></p>
     </div>
   </div>
 </section>
 
 <section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Key features</h2>
+    </div>
+  </div>
   <div class="row">
     <div class="col-12">
       <ul class="p-list is-split u-no-margin--bottom">
@@ -45,6 +55,11 @@
 </section>
 
 <section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Why use Dqlite</h2>
+    </div>
+  </div>
   <div class="row">
     <ul class="p-matrix u-no-margin--bottom">
       <li class="p-matrix__item">
@@ -113,7 +128,7 @@
   <div class="row">
     <div class="col-7">
       <h2>Why Raft?</h2>
-      <p>Consensus algorithms provide certainty of transaction replication.  It ensures data persistence in the event of the loss of one or more machines in the cluster, as long as a majority survives. Raft is widely considered the consensus algorithm of choice for efficiency and correctness of implementation. <a href="http://github.com/canonical/raft">C-Raft</a> is a hand-tuned C implementation of Raft that is fully asynchronous by design.</p>
+      <p>Consensus algorithms provide certainty of transaction replication. It ensures data persistence in the event of the loss of one or more machines in the cluster, as long as a majority survives. Raft is widely considered the consensus algorithm of choice for efficiency and correctness of implementation. <a href="http://github.com/canonical/raft" aria-label="External link to the C-Raft Github project page" class="p-link--external">C-Raft</a> is a hand-tuned C implementation of Raft that is fully asynchronous by design.</p>
     </div>
   </div>
 </section>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -10,7 +10,7 @@
             </a>
           </li>
           <li class="p-inline-list__item">
-            <a aria-label="External link to report a bug on this site" href="https://github.com/canonical-web-and-design/dqlite.io/issues/new">
+            <a aria-label="External link to report a bug on Github" href="https://github.com/canonical-web-and-design/dqlite.io/issues/new">
               Report a bug on this site
             </a>
           </li>

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -2,16 +2,16 @@
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo u-vertically-center">
-        <a class="p-navigation__link" href="/" style="color:white;">
+        <a class="p-navigation__link" href="/" style="color:white;" aria-label="Back to homepage">
           Dqlite
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+      <a href="#" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
       <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
+        <a href="#main-content" class="p-link--inverted">Jump to main content</a>
       </span>
       <ul class="p-navigation__links" role="menu">
         <li class="p-navigation__link {% if request.path in ['/docs', '/docs/faq', '/docs/protocol'] %}is-selected{% endif %}" role="menuitem">


### PR DESCRIPTION
## Done
A number of copy and aria attrs to improve a11y. In doing so, have improved the SEO of the site.

## QA
- On Ubuntu hit `Super + Alt + S` to enable Orca.
- Use the arrow keys to move through the site and tab between links
- Ensure they are well read out and you understand everywhere the links will take you
- Use WAVE (browser plugin) to ensure we have no a11y errors remaining.

